### PR TITLE
Slight change to ->send to comply with IRC specs

### DIFF
--- a/SpringIrcBridge.pm
+++ b/SpringIrcBridge.pm
@@ -262,9 +262,9 @@ sub send {
     $sl->log("Unable to send command \"$command\" to IRC client, not connected!".logSuffix(),1);
   }else{
     my $ircSock=$self->{ircSock};
-    print $ircSock "$command\cJ";
-    print $ircSock ":DEBUG PRIVMSG \&debug_irc :[\cC04 C <- B \cC01] $command\cJ" if($self->{isInDebugIrc} && ! $noDebug);
-    print $ircSock ":DEBUG PRIVMSG \&debug :[\cC04 C <- B      \cC01] $command\cJ" if($self->{isInDebug} && ! $noDebug);
+    print $ircSock "$command\cM\cJ";
+    print $ircSock ":DEBUG PRIVMSG \&debug_irc :[\cC04 C <- B \cC01] $command\cM\cJ" if($self->{isInDebugIrc} && ! $noDebug);
+    print $ircSock ":DEBUG PRIVMSG \&debug :[\cC04 C <- B      \cC01] $command\cM\cJ" if($self->{isInDebug} && ! $noDebug);
   }
 }
 


### PR DESCRIPTION
Hiya Yaribz!

I started hacking up a quick IRC bot to interact with #s44 on the spring server, but the client library I was using (Mojo::IRC) only accepted `\r\n` as message terminator, per IRC spec. I got a patch accepted to that library to handle just `\n` gracefully, but I figured I'd submit a PR here as well, so that other 'strictly complying' clients will also be able to interact with the Spring IRC bridge.

Thanks!